### PR TITLE
Tests to Clarify More Details

### DIFF
--- a/invalid.txt
+++ b/invalid.txt
@@ -1,0 +1,21 @@
+H(not a header)‘...’|
+
+|H(0b1)‘binary’|
+
+|H(0xA)‘hexadecimal’|
+
+|H(0xa)‘lower case hexadecimal’|
+
+|H(−1)‘minus instead of ASCII hyphen’|
+
+|H(1 0)‘space digit separator’
+
+|H(1,0)‘comma digit separator’|
+
+|H(1.0)‘dot digit separator’|
+
+|H(1,1)‘decimal comma’|
+
+|H(1.1)‘decimal dot’|
+
+|H(²)‘superscript’

--- a/tests.txt
+++ b/tests.txt
@@ -1,5 +1,7 @@
 *‘bold’ (()) <b>bold</b>|
 
+|*‘̆ (combining character)’ (()) <b>̆ (combining character)</b>|
+
 |_‘underlined’ (()) <u>underlined</u>|
 
 |-‘strikethrough’ (()) <s>strikethrough</s>|
@@ -10,9 +12,29 @@
 H(1)‘header’ (()) <h3>header</h3>
 <h2>header</h2>|
 
+|Not a Header (()) Not a Header|
+
+|H(... ...not a header (()) H(... ...not a header|
+
+|H(not a header) (()) H(not a header)|
+
 |H(+1)‘header’ (()) <h2>header</h2>|
 
 |H(-1)‘header’ (()) <h4>header</h4>|
+
+|H(01)‘leading zero’ (()) <h2>leading zero</h2>|
+
+|H(7)‘too high’ (()) <h1>too high</h1>|
+
+|H(-7)‘too low’ (()) <h6>too low</h6>|
+
+|H( 1 )‘spaced’ (()) <h2>spaced</h2>|
+
+|H(1_0)‘underscore digit separator’ (()) <h1>underscore digit separator</h1>|
+
+|H(１)‘full width’ (()) <h2>full width</h2>|
+
+|H(١)‘arabic digits’ (()) <h2>arabic digits</h2>|
 
 |[http://address] (()) <a href="http://address">http://address</a>|
 


### PR DESCRIPTION
In the interest of actually making sure the various implementations match, I have added a bunch of tests to clarify some details. These are things I had to look up or experiment with to see how Python works in order to mimic it.

Those added to `tests.txt` are supported by the current Python implementation (intentionally or by accident).

Those in the new file are rejected by the current Python implementation with an error message (intentionally or by accident).

They will help enforce that not just the Swift implementation, but all languages’ implementations actually do the same thing when it comes to parsing Unicode, integers, parentheses, etc.

(I do not know if the C or Nim implementations successfully handle these yet.)